### PR TITLE
fix(symlink): use junction type for Windows compatibility with pnpm

### DIFF
--- a/lib/copy.js
+++ b/lib/copy.js
@@ -386,7 +386,7 @@ function copyFile(srcPath, destPath, stats, options) {
 function copySymlink(srcPath, destPath, stats, options) {
 	return readlink(srcPath)
 		.then(function(link) {
-			return symlink(link, destPath);
+			return symlink(link, destPath, options?.symlinkType ?? 'junction');
 		});
 }
 


### PR DESCRIPTION
When creating symlinks on Windows without explicit `junction` type, the default behavior may trigger EPERM errors under pnpm environments. This fix ensures cross-platform compatibility by enforcing junction type as default on Windows.